### PR TITLE
Renamed options & log file fixes

### DIFF
--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -44,7 +44,7 @@ init {
     vars.timerLogTimes = (EventHandler)((s, e) => {
         if(timer.CurrentPhase == TimerPhase.Ended) {
             string separator = "  |  ";
-			string category = timer.Run.CategoryName;
+	    string category = timer.Run.CategoryName;
             string timesDisplay = "Trackmania - "+category+Environment.NewLine+Environment.NewLine+"   Sum   "+separator+" Segment "+separator+"  Track";
             int cumulatedTime = 0;
             bool isFirst = true;

--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -5,7 +5,7 @@ startup {
     settings.Add("checkpoint", false, "Split at every checkpoint");
 
     settings.Add("cStart", false, "Auto-start on every track");
-    settings.Add("cLog", true, "Log the game time of completed runs into a file (Livesplit folder -> TrackmaniaTimes)");
+    settings.Add("cLog", true, "Log the game time of completed runs in a file (Livesplit folder -> TrackmaniaTimes)");
     settings.Add("cTraining", false, "Training individual splits (overridden by settings 1 and 2)");
     settings.Add("cSeason", false, "Season individual splits (overridden by settings 1 and 2)");
 

--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -6,8 +6,8 @@ startup {
 
     settings.Add("cStart", false, "Auto-start on every track");
     settings.Add("cLog", true, "Log the game time of completed runs in a file (Livesplit folder -> TrackmaniaTimes)");
-    settings.Add("cTraining", false, "Training individual splits (overridden by settings 1 and 2);
-    settings.Add("cSeason", false, "Season individual splits (overridden by settings 1 and 2);
+    settings.Add("cTraining", false, "Training individual splits (overridden by settings 1 and 2)";
+    settings.Add("cSeason", false, "Season individual splits (overridden by settings 1 and 2)";
 
     for (int trackId = 1; trackId < 26; trackId++) {
         string trackNb = trackId.ToString("D2");

--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -42,7 +42,7 @@ startup {
 
 init {
     vars.timerLogTimes = (EventHandler)((s, e) => {
-        if(timer.CurrentPhase == TimerPhase.Ended) {
+        if(settings["cLog"] && timer.CurrentPhase == TimerPhase.Ended) {
             string separator = "  |  ";
 	    string category = timer.Run.CategoryName;
             string timesDisplay = "Trackmania - "+category+Environment.NewLine+Environment.NewLine+"   Sum   "+separator+" Segment "+separator+"  Track";

--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -5,9 +5,9 @@ startup {
     settings.Add("checkpoint", false, "Split at every checkpoint");
 
     settings.Add("cStart", false, "Auto-start on every track");
-    settings.Add("cLog", true, "Log the game time of completed runs in a file (Livesplit folder -> TrackmaniaTimes)");
-    settings.Add("cTraining", false, "Training individual splits (overridden by settings 1 and 2)";
-    settings.Add("cSeason", false, "Season individual splits (overridden by settings 1 and 2)";
+    settings.Add("cLog", true, "Log the game time of completed runs into a file (Livesplit folder -> TrackmaniaTimes)");
+    settings.Add("cTraining", false, "Training individual splits (overridden by settings 1 and 2)");
+    settings.Add("cSeason", false, "Season individual splits (overridden by settings 1 and 2)");
 
     for (int trackId = 1; trackId < 26; trackId++) {
         string trackNb = trackId.ToString("D2");
@@ -35,7 +35,7 @@ startup {
         return vars.loadMap.Current.Substring(vars.loadMap.Current.Length-3, 2);
     });
 
-	vars.GetMapName = (Func<string>)(() => {
+    vars.GetMapName = (Func<string>)(() => {
 		return System.Text.RegularExpressions.Regex.Replace(vars.loadMap.Current.Substring(0, vars.loadMap.Current.Length-1), "(\\$[0-9a-fA-F]{3}|\\$[wnoitsgz]{1})", "");
 	});
 }
@@ -63,7 +63,6 @@ init {
                 Directory.CreateDirectory(directoryName);
             File.AppendAllText(path, timesDisplay);
         }
-    });
     });
     timer.OnSplit += vars.timerLogTimes;
 

--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -136,7 +136,7 @@ split {
     if(vars.raceTime.Old != vars.raceTime.Current && (vars.lastCP.Item1 != vars.loadMap.Current || vars.lastCP.Item2 < vars.checkpoint.Current)) {
         vars.lastCP = Tuple.Create(vars.loadMap.Current, vars.checkpoint.Current);
         if(vars.isFinished.Current) {
-            vars.logTimes.Add(vars.GetCleanMapName(), vars.gameTime.Current);
+            vars.logTimes.Add(vars.GetMapName(), vars.gameTime.Current);
             if(settings["track"]) {
                 return true;
             } else {
@@ -167,7 +167,7 @@ gameTime {
         if(!vars.isFinished.Current || vars.lastCP.Item1 != vars.loadMap.Current) {
             int resetNb = 1;
             while(true) {
-                string timeEntry = vars.GetCleanMapName()+" (Reset "+resetNb+")";
+                string timeEntry = vars.GetMapName()+" (Reset "+resetNb+")";
                 if(!vars.logTimes.ContainsKey(timeEntry)) {
                     vars.logTimes.Add(timeEntry, vars.gameTime.Old);
                     break;


### PR DESCRIPTION
Extended string watcher from 24 to 64 characters for map names.
Edited the description of a couple options
Added regex expression to remove formatting from map names
Removed first part of the log file and added the category name to the name of the file and on the first line of the file.
Added auto-reset only on the map that started the timer.