### PR TITLE
Re-adding log file option until new tutorial

### DIFF
--- a/Livesplit.Trackmania/Livesplit.Trackmania.asl
+++ b/Livesplit.Trackmania/Livesplit.Trackmania.asl
@@ -5,6 +5,7 @@ startup {
     settings.Add("checkpoint", false, "Split at every checkpoint");
 
     settings.Add("cStart", false, "Auto-start on every track");
+    settings.Add("cLog", true, "Log detailed game time of completed runs into a file (Livesplit folder -> TrackmaniaTimes)");
     settings.Add("cTraining", false, "Training individual splits (overridden by \"all tracks/checkpoints\" settings)");
     settings.Add("cSeason", false, "Season individual splits (overridden by \"all tracks/checkpoints\" settings)");
 


### PR DESCRIPTION
To not confuse new speedrunners who will watch the current tutorial video, log file option will still be shown in the autosplitter settings.
In the updated tutorial video that will come in a couple weeks, the log file option will disappear and log files will be created by default.